### PR TITLE
Summary of Changes:

### DIFF
--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -337,12 +337,14 @@ def _move_item(old_inventory, new_inventory, item):
 
 
 # TODO: Collapse with read?
-# TODO: Unfortunate that you can't say stuff like "smoke" or whatever.
-# TODO: Fucccckkk I could create a @when decorator in the item subclasses
-# themselves with a decorator on the specific methods (e.g. consume()).
-@adventurelib.when("use ITEM")
-@when.when("consume ITEM")
-def use(item):
+# TODO: Could create a @when decorator in the item subclasses
+# themselves that automatically registers a command.
+# TODO: Refactor items; let items have "verb" objects which map to events.
+@adventurelib.when("use ITEM", verb="use")
+@adventurelib.when("eat ITEM", verb="eat")
+@adventurelib.when("smoke ITEM", verb="smoke")
+@when.when("consume ITEM", verb="consume")
+def use(item, verb):
     item_name = item
     item = G.player.inventory.find(item_name)
     if item is None:

--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -24,9 +24,7 @@ def _look():
     # TODO: Fix a(n) problems throughout code base.
     for item in G.player.current_room.items:
         say.insayne(f"There is a(n) {item.name} lying on the ground.")
-    for character in G.player.current_room.characters:
-        if character is G.player:
-            continue
+    for character in G.player.current_room.npcs:
         # TODO: Move these descriptions to the actor.
         say.insayne(
             f"There is a(n) {character.name} slobbering in the corner."
@@ -183,7 +181,7 @@ def _resolve_attack(attacker, attack):
 
 
 def _get_present_actor(actor_name):
-    return G.player.current_room.characters.find(actor_name)
+    return G.player.current_room.npcs.find(actor_name)
 
 
 @when.when("ability ABILITY")
@@ -231,8 +229,11 @@ def attack(actor):
         return
 
     # TODO: Move this to player AI. Use defender as a "hint."
+    # TODO: Migrating to player AI will avoid the special-casing of Room.npcs.
+    # TODO: Migrating to player AI can also allow for a more nuanced
+    # menu when attacking.
     _resolve_attack(G.player, ai.Attack(target=defender, method=None))
-    for character in G.player.current_room.characters:
+    for character in G.player.current_room.npcs:
         assert character.ai is not None
         action = character.ai.choose_action(G.player.current_room)
         if action.attack is not None:
@@ -291,7 +292,7 @@ def inspect(item):
             say.insayne(item.description, add_newline=False)
         return
 
-    character = G.player.current_room.characters.find(item_name)
+    character = G.player.current_room.npcs.find(item_name)
     if character is not None:
         # TODO: Collapse this with descriptive text in look().
         say.insayne(f"There is a(n) {character.name} slobbering in the corner.")
@@ -378,8 +379,8 @@ def drop(item):
         _move_item(G.player.inventory, G.player.current_room.items, item)
 
 
-@adventurelib.when("loot ITEM from CORPSE")
-@when.when("loot CORPSE", item="everything")
+@adventurelib.when("loot CORPSE", item="everything")
+@when.when("loot ITEM from CORPSE")
 def loot(item, corpse):
     item_name = item
     corpse_name = corpse
@@ -390,12 +391,10 @@ def loot(item, corpse):
     if character is not None:
         message = "You cannot loot the living!"
         # TODO: What if none of the character present chooses to attack?
-        if any(character.alive for character in G.player.current_room.characters):
+        if G.player.current_room.npcs:
             message += " All enemies attack as your clumsy pickpocketing attempt fails."
         say.insayne(message)
-        for character in G.player.current_room.characters:
-            if not character.alive:
-                continue
+        for character in G.player.current_room.npcs:
             assert character.ai is not None
             action = character.ai.choose_action(G.player.current_room)
             if action.attack is not None:
@@ -412,7 +411,7 @@ def loot(item, corpse):
         if item_name in {"all", "everything"}:
             items = {item.name: item for item in corpse.inventory}
         else:
-            items = {item_name: [corpse.inventory.find(item_name)]}
+            items = {item_name: corpse.inventory.find(item_name)}
         for name, item in items.items():
             if item is None:
                 say.insayne(f"There is no {item.name} on the corpse.")

--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -404,7 +404,7 @@ def loot(item, corpse):
 
     # TODO: This is duplicated from above. Maybe an "interact" function is
     # called for?
-    corpse = G.player.current_room.characters.find(corpse_name)
+    corpse = G.player.current_room.corpses.find(corpse_name)
     if corpse is None:
         say.insayne(f"There is no {corpse_name} here.")
 

--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -364,7 +364,6 @@ def take(item):
     if location is None or item is None:
         say.insayne(f"There is no {item_name} here to take.")
     else:
-        say.insayne(f"You acquire the {item_name}.")
         _move_item(location, G.player.inventory, item)
 
 

--- a/cronenbroguelike/items.py
+++ b/cronenbroguelike/items.py
@@ -95,3 +95,10 @@ class Cigarette(_Consumable):
     @classmethod
     def create(cls):
         return cls("cigarette", "smoke", "coffin nail", "cancer stick")
+
+
+class Lighter(_Item):
+    
+    @classmethod
+    def create(cls):
+        return cls("lighter")

--- a/cronenbroguelike/npcs.py
+++ b/cronenbroguelike/npcs.py
@@ -122,13 +122,11 @@ def smokes_man():
                     'smoke with me. It\'s all there is to do here, man. Just '
                     'that and wait to die and live again."')
                 _G.player.inventory.add(cigarette)
-                say.insayne(f"You acquire a {cigarette.name}.")
                 lighter = npc.inventory.find("lighter")
                 if lighter is not None:
                     say.insayne('"Here, you\'ll need this, too."')
                     npc.inventory.remove(lighter)
                     _G.player.inventory.add(lighter)
-                    say.insayne(f"You acquire a {lighter.name}.")
                     say.insayne('"No smoke without fire."')
 
     npc.ai.add_event(_SmokesManEvent())

--- a/cronenbroguelike/npcs.py
+++ b/cronenbroguelike/npcs.py
@@ -98,6 +98,7 @@ def smokes_man():
         10,
         100,
         "smoker",
+        "smokes man",
         "dude",
         "chill dude",
         "guy",
@@ -122,6 +123,13 @@ def smokes_man():
                     'that and wait to die and live again."')
                 _G.player.inventory.add(cigarette)
                 say.insayne(f"You acquire a {cigarette.name}.")
+                lighter = npc.inventory.find("lighter")
+                if lighter is not None:
+                    say.insayne('"Here, you\'ll need this, too."')
+                    npc.inventory.remove(lighter)
+                    _G.player.inventory.add(lighter)
+                    say.insayne(f"You acquire a {lighter.name}.")
+                    say.insayne('"No smoke without fire."')
 
     npc.ai.add_event(_SmokesManEvent())
 
@@ -136,5 +144,9 @@ def smokes_man():
     number_butts = random.choice(range(4, 7))
     for _ in range(number_butts):
         npc.inventory.add(items.CigaretteButt.create())
+    npc.inventory.add(items.CigaretteStub.create())
+    npc.inventory.add(items.CigaretteStub.create())
+    npc.inventory.add(items.Cigarette.create())
+    npc.inventory.add(items.Lighter.create())
 
     return npc

--- a/demo.py
+++ b/demo.py
@@ -4,7 +4,7 @@ import logging
 def _load_config():
     import json
 
-    config = {"log_level": "INFO"}
+    config = {"log_level": "INFO", "num_rooms": 15}
     try:
         with open("config.json", "r") as inp:
             additional_config = json.load(inp)
@@ -12,11 +12,12 @@ def _load_config():
         additional_config = {}
 
     config.update(additional_config)
-    log_level = config["log_level"].upper()
-    logging.basicConfig(level=getattr(logging, log_level))
+    config["log_level"] = config["log_level"].upper()
+    return config
 
 
-_load_config()
+CONFIG = _load_config()
+logging.basicConfig(level=getattr(logging, log_level))
 
 
 import random
@@ -77,7 +78,7 @@ def _start_game(_):
     G.player.upon_death(startgame)
 
     # Creates a small dungeon.
-    level = floor.Floor.generate("cathedral", number_rooms=15)
+    level = floor.Floor.generate("cathedral", number_rooms=CONFIG["num_rooms"])
 
     # Places a monster in a random room.
     level.random_room().add_character(npcs.fish_man())

--- a/engine/bag.py
+++ b/engine/bag.py
@@ -12,9 +12,9 @@ class Bag(_Bag):
         super()._add_aliases(item)
         logging.debug(f'_add_aliases called with {item}')
         if self is _G.player.inventory:
-            say.insayne("You acquire {item.name}.")
+            say.insayne(f"You acquire {item.name}.")
 
     def _discard_aliases(self, item):
         super()._discard_aliases(item)
         if self is _G.player.inventory:
-            say.insayne("You no longer possess {item.name}.")
+            say.insayne(f"You lose possession of {item.name}.")

--- a/engine/room.py
+++ b/engine/room.py
@@ -3,6 +3,7 @@ import collections
 import adventurelib
 
 from engine import bag
+from engine.globals import G as _G
 from engine import say
 
 
@@ -40,6 +41,10 @@ class Room(adventurelib.Room):
     @property
     def characters(self):
         return self._characters
+
+    @property
+    def npcs(self):
+        return self._characters.difference({_G.player})
 
     def add_item(self, item):
         self._items.add(item)


### PR DESCRIPTION
Adds a lighter.
Fixes bug where looting didn't actually access Room.corpses.
Fixes #22 by adding .npcs property to room, which omits player (whose .ai is None).
Switches decorator order on loot() to bypass adventurelib parsing quirk.
Formats messages found in bag.py. Removes extraneous messages when acquiring items.
Makes number of rooms configurable in config.