### PR TITLE
Summary of Changes:

### DIFF
--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -23,7 +23,7 @@ def _look():
     # TODO: Bespoke descriptions for all items and characters.
     # TODO: Fix a(n) problems throughout code base.
     for item in G.player.current_room.items:
-        say.insayne(f"There is a(n) {item.name} lying on the ground.")
+        say.insayne(item.idle_description)
     for character in G.player.current_room.npcs:
         # TODO: Move these descriptions to the actor.
         say.insayne(

--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -373,6 +373,7 @@ def use(item, verb):
         item.consume(G.player)
     except AttributeError:
         say.insayne(f"You can't use the {item_name}.")
+        raise
 
 
 @adventurelib.when("take ITEM")

--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -370,6 +370,8 @@ def take(item):
     location, item = _find_in_room(item_name)
     if location is None or item is None:
         say.insayne(f"There is no {item_name} here to take.")
+    elif not item.obtainable:
+        say.insayne("You can't take the {item_name}.")
     else:
         _move_item(location, G.player.inventory, item)
 

--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -220,7 +220,7 @@ def attack(actor):
     # TODO: Affinity/factions so monsters can choose whom to strike.
     defender = _get_present_actor(actor_name)
     if defender is None:
-        say.insayne(f"There is no {actor_name} here.")
+        say.insayne(f"There is no {actor_name} here to attack.")
         return
 
     if not defender.alive:
@@ -250,7 +250,18 @@ def talk(actor):
     actor_name = actor  # Variable names are constrained by adventurelib.
     interlocutor = _get_present_actor(actor_name)
     if interlocutor is None:
-        say.insayne(f"There is no {actor_name} here.")
+        if _find_available_item(actor_name) is not None:
+            if _G.player.insanity > 30:
+                say.insayne(
+                        f"You talk to {actor_name} at length. In response, "
+                        "it expatiates on the nature of reality. It's making "
+                        f"a lot of sense, that talking {actor_name}.")
+                _G.player.insanity.modify(15)
+            else:
+                say.insayne(f"Why are you talking to {actor_name}, crazy?")
+                _G.player.insanity.modify(5)
+        else:
+            say.insayne(f"There is no {actor_name} here to talk to.")
         return
 
     if not interlocutor.alive:

--- a/cronenbroguelike/items.py
+++ b/cronenbroguelike/items.py
@@ -61,12 +61,16 @@ class CigaretteStub(_Consumable):
             say.insayne(f'You have no way to light the {self.name}.')
             return
 
-        # TODO: Customize text based on whether consumer is player.
-        say.insayne(
-                f"You take a furtive puff on the {self.name}. It tastes foul "
-                "and acrid. You do not feel like you are wearing a leather "
-                "jacket at all.")
-        consumer.health.heal_or_harm(- dice.roll("2d2"))
+        if consumer is _G.player:
+            say.insayne(
+                    f"You take a furtive puff on the {self.name}. It tastes foul "
+                    "and acrid. You do not feel like you are wearing a leather "
+                    "jacket at all.")
+            consumer.health.heal_or_harm(- dice.roll("2d2"))
+        else:
+            name = consumer.name[0].upper() + consumer.name[1:]
+            say.insayne(f"{name} puffs furtively on a {self.name}.")
+        
         consumer.inventory.remove(self)
         cigarette_butt = CigaretteButt.create()
         consumer.inventory.add(cigarette_butt)
@@ -88,13 +92,19 @@ class Cigarette(_Consumable):
         # TODO: Add location to actors so that the state of onlookers can
         # be properly assessed.
         aliases = random.sample(self.aliases, 2)
-        say.insayne(
-                f"You take a long, smooth drag on the {aliases[0]}. Time seems "
-                "to mellow; all activity nearby slows. Onlookers watch as you "
-                "draw measured, pensive little puffs from the delicious "
-                f"{aliases[1]}. You look very cool.")
+        if consumer is _G.player:
+            say.insayne(
+                    f"You take a long, smooth drag on the {aliases[0]}. Time seems "
+                    "to mellow; all activity nearby slows. Onlookers watch as you "
+                    "draw measured, pensive little puffs from the delicious "
+                    f"{aliases[1]}. You look very cool.")
+            consumer.health.heal_or_harm(- dice.roll("1d2"))
+        else:
+            name = consumer.name[0].upper() + consumer.name[1:]
+            say.insayne(f"{name} puffs mellowly on a {self.name}, looking extremely fly.")
+
         # TODO: Buff strength for a little bit.
-        consumer.health.heal_or_harm(- dice.roll("1d2"))
+        # TODO: Heal insanity, restore psyche.
         # TODO: I don't like this solution as it presumes the item is in the
         # consumer's inventory. Maybe that is a fine assumption. If not,
         # consider storing the inventory relationship as two-way.

--- a/cronenbroguelike/items.py
+++ b/cronenbroguelike/items.py
@@ -102,3 +102,23 @@ class Lighter(_Item):
     @classmethod
     def create(cls):
         return cls("lighter")
+
+
+# TODO: Maybe make ephemeral items and have a global event that polls for them,
+# changing their state?
+class Smoke(_Item):
+
+    @classmethod
+    def create(cls):
+        return cls(
+                "event_smoke", description="plumes of smoke",
+                idle_description="Thick wreaths of acrid smoke hang in the air.")
+
+
+class FadingSmoke(_Item):
+
+    @classmethod
+    def create(cls):
+        return cls(
+                "event_smoke", description="plumes of smoke",
+                idle_description="A thin haze of smoke remains here.")

--- a/cronenbroguelike/npcs.py
+++ b/cronenbroguelike/npcs.py
@@ -110,7 +110,7 @@ def smokes_man():
 
         def execute(self):
             # TODO: Should not be G.player--what if somebody else wants a smoke?
-            if _G.player.inventory.find("smoke"):
+            if _G.player.inventory.find("cigarette") or _G.player.inventory.find("stub"):
                 say.insayne(
                         'The smoker clucks his tongue. "You\'ve already got a '
                         'smoke; why are you trying to bum one off me?"')

--- a/cronenbroguelike/npcs.py
+++ b/cronenbroguelike/npcs.py
@@ -113,7 +113,7 @@ def smokes_man():
             if _G.player.inventory.find("smoke"):
                 say.insayne(
                         'The smoker clucks his tongue. "You\'ve already got a '
-                        'smoke; why are you trying to bum one off me?')
+                        'smoke; why are you trying to bum one off me?"')
 
             else:
                 cigarette = random.choice(

--- a/cronenbroguelike/npcs.py
+++ b/cronenbroguelike/npcs.py
@@ -2,6 +2,7 @@ import random
 
 from engine import actor
 from engine import ai
+from engine import dice
 from engine import event
 from engine.globals import G as _G
 from engine import say
@@ -74,7 +75,7 @@ def mad_librarian():
             npc.die()
             self._will_execute = False
 
-    npc.ai.add_event(_LibrarianEvent())
+    npc.ai.add_event(_LibrarianEvent(), "talk")
 
     def librarian_death_throes(librarian):
         say.insayne(
@@ -130,7 +131,26 @@ def smokes_man():
                     _G.player.inventory.add(lighter)
                     say.insayne('"No smoke without fire."')
 
-    npc.ai.add_event(_SmokesManEvent())
+    class _SmokesManSmokes(event.Event):
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.owner = None
+            self._timer = -1
+
+        def execute(self):
+            self._timer += 1
+            if self._timer % 3 != 0:
+                return
+            roll = dice.roll('1d10')
+            if roll <= 4:
+                return
+            cig = items.Cigarette.create()
+            self.owner.inventory.add(cig)
+            cig.consume(self.owner)
+
+    npc.ai.add_event(_SmokesManEvent(), "talk")
+    npc.ai.add_default_event(_SmokesManSmokes())
 
     def smoker_death_throes(smoker):
         say.insayne(

--- a/cronenbroguelike/rooms.py
+++ b/cronenbroguelike/rooms.py
@@ -129,10 +129,54 @@ cathedral_belfry = _BelfryRoom.create(
 )
 
 
+class _AltarEvent(_Event):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def execute(self):
+        smoke = self.room.items.find('smoke') or self.room.items.find('fading smoke')
+        if smoke is not None:
+            say.insayne(
+                "The smoke whirls for a moment on the altar as though set "
+                "there for an offering. "
+                "The idol's ruby eyes seem to blaze as the smoke makes "
+                "languorous curls beneath its nose. With a sound like the "
+                "clatter of gravel and like the snuffling of many beasts, the "
+                "idol draws the smoke into its nostrils. Its mouth shudders "
+                "and falls open, smashing the altar beneath to shards. ")
+            say.insayne("All beings present are pelted with debris.")
+            for character in self.room.characters:
+                character.health.heal_or_harm(-1)
+            say.insayne(
+                "In the idol's lax jaws can be seen a passage "
+                "winding downard.")
+            self.room.description = (
+                "An idol with ruby eyes and a soot-stained maw yawns at you. "
+                "Its throat, of an almost irritated red color, is large enough "
+                "for you to pass through. The idol's mandible lies atop a pile "
+                "of rubble. Fragments of stone are "
+                "punctuated with the remains of an ivory frieze. One "
+                "piece of ivory appears to depict the idol itself, its mouth "
+                "cavernous, the red gold of its eyes showing contentment.")
+            G.set_flag("IDOL_MOUTH_OPEN")
+            self.room.items.remove(smoke)
+            self.kill()
+
+
 class _AltarRoom(_Room):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._event = None
     
     def on_enter(self):
         super().on_enter()
+        if self._event is None:
+            self._event = _AltarEvent()
+            # TODO: Use add_event here and elsewhere; omit _maybe_append_event from Room.add_event.
+            self._event.room = self
+            G.add_event(self._event, "post")
         adventurelib.set_context("altar")
 
     def on_exit(self):
@@ -140,13 +184,15 @@ class _AltarRoom(_Room):
         adventurelib.set_context(None)
 
 
+# TODO: Add a battle with a wrathful being if the smoker is slain.
 cathedral_altar = _AltarRoom.create(
     "An idol with ruby eyes and a soot-stained maw sneers at you, showing "
     "carven fangs. Directly beneath its chin sits an altar, resting atop a "
     "stone plinth. Its sides are embellished with bas-relief ivory friezes "
     "depicting various acts both lewd and violent. On one side is depicted "
-    "the apparent sacrifice of a man wrapped in leaves. The smoke rises up to "
-    "a face, which is depicted grinning.",
+    "the apparent sacrifice of a man bearing a sprig of leaves, overseen by an angry "
+    "beast. On another is shown a burnt offering of the same leaves. The smoke "
+    "rises up toward a face, whose mouth gapes in a slack-jawed smile.",
     theme="cathedral",
 )
 

--- a/engine/actor.py
+++ b/engine/actor.py
@@ -156,6 +156,8 @@ class Actor:
             self._statistics[statistic.name] = statistic
             statistic.owner = self
         self._ai = kwargs.pop("ai", None)
+        if self._ai is not None:
+            self._ai.owner = self
         self._death_throes = lambda this: None
         self._inventory = bag.Bag()
         self._read_books = set()
@@ -196,6 +198,8 @@ class Actor:
     # TODO: This sucks; using __getattr__ or something might help. Maybe just
     # hard-code the stats that all actors have? Dynamically add properties?
     # ... use metaclasses?
+    # TODO: How does this change when equipment is added?
+    # TODO: How does this change when body-swapping is added?
     def get_stat(self, stat_name):
         stat = self._statistics.get(stat_name)
         if stat is not None:

--- a/engine/ai.py
+++ b/engine/ai.py
@@ -1,4 +1,6 @@
 import collections
+import copy
+import random
 
 from engine.globals import G as _G
 
@@ -37,22 +39,50 @@ class _Action:
 
 
 class AI:
-    def choose_action(self, room):
+    def __init__(self):
+        self.owner = None  # Fully mutable member.
+
+    def choose_action(self, room, impulse=None):
         return NotImplemented
 
 
 class HatesPlayer(AI):
-    def choose_action(self, unused_room):
+    def choose_action(self, unused_room, impulse=None):
         # TODO: Is there an elegant way to make current_room aware of player?
         return _Action(Attack(target=_G.player, method=None))
 
 
 class Chill(AI):
     def __init__(self):
-        self._event = None
+        super().__init__()
+        self._events = {}
+        self._default_event = None
 
-    def add_event(self, event):
-        self._event = event
+    def add_event(self, event, impulse):
+        assert impulse is not None
+        self._events.setdefault(impulse, set()).add(event)
 
-    def choose_action(self, unused_room):
-        return _Action(Event(self._event))
+    def add_default_event(self, event):
+        # TODO: All of this owner stuff could be avoided by passing a context
+        # to Event.execute() ... 
+        self._default_event = event
+
+    def choose_action(self, unused_room, impulse=None):
+        if impulse in self._events:
+            event_set = self._events.get(impulse, set())
+        else:
+            event_set = set()
+        if event_set:
+            result = random.sample(event_set, 1)[0]
+        else:
+            result = self._default_event
+        if result is not None:
+            # TODO: deepcopy is a terrible way to fix this issue. Events should be
+            # passes as classes, not instances. deepcopy absolutely barfs on
+            # circular dependencies.
+            result_copy = copy.deepcopy(result)
+            result_copy.owner = self.owner
+            event = Event(result_copy)
+        else:
+            event = None
+        return _Action(event)

--- a/engine/bag.py
+++ b/engine/bag.py
@@ -11,10 +11,12 @@ class Bag(_Bag):
     def _add_aliases(self, item):
         super()._add_aliases(item)
         logging.debug(f'_add_aliases called with {item}')
+        item.holder = self
         if self is _G.player.inventory:
             say.insayne(f"You acquire {item.name}.")
 
     def _discard_aliases(self, item):
         super()._discard_aliases(item)
+        item.holder = None
         if self is _G.player.inventory:
             say.insayne(f"You lose possession of {item.name}.")

--- a/engine/globals.py
+++ b/engine/globals.py
@@ -51,6 +51,9 @@ class _GameState:
         while self._text_queue:
             yield self._text_queue.popleft()
 
+    def set_flag(self, flag):
+        logging.debug('set_flag called')
+
 
 G = _GameState()
 

--- a/engine/item.py
+++ b/engine/item.py
@@ -4,13 +4,17 @@ from adventurelib import Item as _Item
 # TODO: Maybe items should store a reciprocal reference to their containing
 # inventory?
 class Item(_Item):
-    def __init__(self, *aliases, description=None):
+    def __init__(
+            self, *aliases, description=None, idle_description=None):
         """Throws ValueError if no aliases are provided."""
         name, *aliases = aliases
         super().__init__(name, *aliases)
         if description is None:
             description = f"a {name}"
+        if idle_description is None:
+            idle_description = f"There is a {name} lying on the ground."
         self.description = description  # Fully mutable member.
+        self.idle_description = idle_description  # Fully mutable member.
 
 
 class Consumable(Item):

--- a/engine/item.py
+++ b/engine/item.py
@@ -19,6 +19,7 @@ class Item(_Item):
             idle_description = f"There is a {name} lying on the ground."
         self.description = description  # Fully mutable member.
         self.idle_description = idle_description  # Fully mutable member.
+        self.holder = None  # Fully mutable member.
         self._obtainable = obtainable
 
     @property

--- a/engine/item.py
+++ b/engine/item.py
@@ -3,9 +3,13 @@ from adventurelib import Item as _Item
 
 # TODO: Maybe items should store a reciprocal reference to their containing
 # inventory?
+# TODO: Inheritance was a bad move here. Composition would be better: each
+# item can have a consumable, a readable, an ephemeral, etc. as members.
 class Item(_Item):
+
     def __init__(
-            self, *aliases, description=None, idle_description=None):
+            self, *aliases, description=None, idle_description=None,
+            obtainable=True):
         """Throws ValueError if no aliases are provided."""
         name, *aliases = aliases
         super().__init__(name, *aliases)
@@ -15,6 +19,11 @@ class Item(_Item):
             idle_description = f"There is a {name} lying on the ground."
         self.description = description  # Fully mutable member.
         self.idle_description = idle_description  # Fully mutable member.
+        self._obtainable = obtainable
+
+    @property
+    def obtainable(self):
+        return self._obtainable
 
 
 class Consumable(Item):

--- a/engine/room.py
+++ b/engine/room.py
@@ -22,8 +22,6 @@ class Room(adventurelib.Room):
         self._display_exits = {}
         self._exits = {}
 
-        # TODO: adventurelib.Bag should contain an ancillary set of aliases
-        # to obviate O(n) lookup by alias.
         self._items = bag.Bag()
         self._characters = bag.Bag()
         self._corpses = bag.Bag()
@@ -94,8 +92,8 @@ class Room(adventurelib.Room):
 
     def add_event(self, event):
         # TODO: This is probably bad.
+        self.event = event
         event.room = self
-        self._maybe_append_event(event)
 
     def events(self):
         # TODO: Rename this method.
@@ -107,9 +105,6 @@ class Room(adventurelib.Room):
                 break
             yield next_event
             self._maybe_append_event(next_event)
-
-    def __call__(self, *args, **kwargs):
-        print(f"I was called with {args} and {kwargs}.")
 
     def exit(self, description):
         return self._exits.get(description, (None, None))


### PR DESCRIPTION
Allows items to differentiate their idle descriptions.
Adds unobtainable items.
Removes unused code and addressed TODOs from engine/room.py.
Fixes typo in smoker banter.
Improves interactivity with objects and clarity of messages in talk() and attack().
Adds lighter for no reason.
Adds smoke to a room when a cigarette is smoked.
Idol opens up when something is smoked in the idol's room.
Adds slightly more nuanced messages for some actions.
Allows for smoker to smoke idly.
Allows NPCs to act on look() command.