### PR TITLE
Ensures that item dictionary in `loot()` can respect multiple items with the same name.

### DIFF
--- a/cronenbroguelike/commands.py
+++ b/cronenbroguelike/commands.py
@@ -397,16 +397,17 @@ def loot(item, corpse):
 
     else:
         if item_name in {"all", "everything"}:
-            items = {item.name: item for item in character.inventory}
+            items = character.inventory.items_by_name()
         else:
-            items = {item_name: character.inventory.find(item_name)}
-        for name, item in items.items():
-            if item is None:
-                say.insayne(f"There is no {name} on the corpse.")
-            else:
-                _move_item(
-                    character.inventory,
-                    G.player.inventory,
-                    item,
-                    acquisition_message=f"You liberate {item.name} from the corpse.",
-                )
+            items = {item_name: [character.inventory.find(item_name)]}
+        for name, item_list in items.items():
+            for item in item_list:
+                if item is None:
+                    say.insayne(f"There is no {name} on the corpse.")
+                else:
+                    _move_item(
+                        character.inventory,
+                        G.player.inventory,
+                        item,
+                        acquisition_message=f"You liberate {item.name} from the corpse.",
+                    )

--- a/engine/bag.py
+++ b/engine/bag.py
@@ -34,3 +34,15 @@ class Bag(_Bag):
     def remove(self, item, message=None):
         set.remove(self, item)
         self._discard_aliases(item, message)
+
+    def items_by_name(self):
+        """Convenience function mapping item names to item lists.
+
+        This is the preferred way to get a name-to-item(s) mapping for a Bag.
+        Naive attempts to do so may result in abstruse bugs when multiple items
+        have the same name.
+        """
+        items = {}
+        for item in self:
+            items.setdefault(item.name, []).append(item)
+        return items

--- a/tests/unit/engine/bag_test.py
+++ b/tests/unit/engine/bag_test.py
@@ -16,7 +16,7 @@ class _Chapstick(item.Item):
 class _BurtsBees(item.Item):
     @classmethod
     def create(cls):
-        return cls("chapstick", "Burt's bees")
+        return cls("chapstick", "burt's bees")
 
 
 class _ChickenWing(item.Item):
@@ -54,20 +54,18 @@ class BagTest(common.EngineTest):
         sequined_clutch.add(_BurtsBees.create())
         actual = sequined_clutch.items_by_name()
         expected = {
-            "chapstick": [_Chapstick.create(), _BurtsBees.create()],
+            "chapstick": [("chapstick",), ("chapstick", "burt's bees")],
             "chicken wing": [
-                _ChickenWing.create(),
-                _ChickenWing.create(),
-                _ChickenWing.create(),
+                ("chicken wing",),
+                ("chicken wing",),
+                ("chicken wing",),
             ],
         }
 
         # Converts items to alias tuples; otherwise, list comparison is hard
-        # because Items are not hashable (meaning they hash on identity).
+        # because Items hash by identity.
         for key, value in actual.items():
             actual[key] = sorted(item.aliases for item in value)
-        for key, value in expected.items():
-            expected[key] = sorted(item.aliases for item in value)
 
         self.assertEqual(expected, actual)
 

--- a/tests/unit/engine/bag_test.py
+++ b/tests/unit/engine/bag_test.py
@@ -55,7 +55,11 @@ class BagTest(common.EngineTest):
         actual = sequined_clutch.items_by_name()
         expected = {
             "chapstick": [_Chapstick.create(), _BurtsBees.create()],
-            "chicken wing": [_ChickenWing.create(), _ChickenWing.create(), _ChickenWing.create()],
+            "chicken wing": [
+                _ChickenWing.create(),
+                _ChickenWing.create(),
+                _ChickenWing.create(),
+            ],
         }
 
         # Converts items to alias tuples; otherwise, list comparison is hard

--- a/tests/unit/engine/bag_test.py
+++ b/tests/unit/engine/bag_test.py
@@ -7,7 +7,25 @@ from engine import item
 from tests import common
 
 
-class BagAddAliasesTest(common.EngineTest):
+class _Chapstick(item.Item):
+    @classmethod
+    def create(cls):
+        return cls("chapstick")
+
+
+class _BurtsBees(item.Item):
+    @classmethod
+    def create(cls):
+        return cls("chapstick", "Burt's bees")
+
+
+class _ChickenWing(item.Item):
+    @classmethod
+    def create(cls):
+        return cls("chicken wing")
+
+
+class BagTest(common.EngineTest):
     def test_add_aliases_adds_holder(self):
         backpack = bag.Bag()
         pamphlet = item.Item("sycophantic propaganda pamphlet")
@@ -27,6 +45,27 @@ class BagAddAliasesTest(common.EngineTest):
         pamphlet = item.Item("sycophantic propaganda pamphlet")
         backpack.add(pamphlet)
         mock_say.assert_not_called()
+
+    def test_items_by_name(self):
+        sequined_clutch = bag.Bag()
+        for _ in range(3):
+            sequined_clutch.add(_ChickenWing.create())
+        sequined_clutch.add(_Chapstick.create())
+        sequined_clutch.add(_BurtsBees.create())
+        actual = sequined_clutch.items_by_name()
+        expected = {
+            "chapstick": [_Chapstick.create(), _BurtsBees.create()],
+            "chicken wing": [_ChickenWing.create(), _ChickenWing.create(), _ChickenWing.create()],
+        }
+
+        # Converts items to alias tuples; otherwise, list comparison is hard
+        # because Items are not hashable (meaning they hash on identity).
+        for key, value in actual.items():
+            actual[key] = sorted(item.aliases for item in value)
+        for key, value in expected.items():
+            expected[key] = sorted(item.aliases for item in value)
+
+        self.assertEqual(expected, actual)
 
 
 class BagDiscardAliasesTest(common.EngineTest):


### PR DESCRIPTION
Generates the item dictionary via a method in `Bag` to prevent other code from making similar mistakes.

Fixes #99 